### PR TITLE
Add Tempest compat

### DIFF
--- a/src/main/resources/data/santan/tempest/spawn_providers/snowy_spawns.json
+++ b/src/main/resources/data/santan/tempest/spawn_providers/snowy_spawns.json
@@ -1,0 +1,23 @@
+{
+  "kind": "snow",
+  "spawners": [
+    {
+      "type": "santan:elf",
+      "weight": 100,
+      "minCount": 2,
+      "maxCount": 3
+    },
+    {
+      "type": "santan:evil_snowman",
+      "weight": 100,
+      "minCount": 1,
+      "maxCount": 3
+    },
+    {
+      "type": "santan:gingerbread_man",
+      "weight": 100,
+      "minCount": 1,
+      "maxCount": 2
+    }
+  ]
+}


### PR DESCRIPTION
In the newest version of Tempest, there's a data-controlled system for adding new spawns in certain types of weather. This PR adds compatibility for Tempest to santan, by letting santan mods spawn not just in snowy biomes, but in any biome when there is a snow-storm.